### PR TITLE
Update AKS Kubernetes Versions to 1.29 major

### DIFF
--- a/bicep/modules/azure-kubernetes-service/README.md
+++ b/bicep/modules/azure-kubernetes-service/README.md
@@ -12,7 +12,7 @@ This module deploys a [Microsoft.ContainerService/managedClusters](https://learn
 | `slaTier` | Defaults to Free tier | `'Free'` <br/> 'Paid' |
 | `managedIdentityType` | Two options are available: SystemAssigned or UserAssigned | `'SystemAssigned'` <br/> `'UserAssigned'` |
 | `userAssignedIdentities` | Required when managed identity type is set to UserAssigned | |
-| `kubernetesVersion` | Default is `1.24.3` | `'1.24.3'` |
+| `kubernetesVersion` | Default is `1.29` | `'1.29'` |
 | `defenderEnabled` | Enables Defender on AKS cluster | `true` or `false` |
 | `imageCleanerEnabled` | Enables ImageCleaner on AKS cluster. | `true` or `false` |
 | `imageCleanerIntervalHours` | ImageCleaner scanning interval in hours | Number |

--- a/bicep/modules/azure-kubernetes-service/main.bicep
+++ b/bicep/modules/azure-kubernetes-service/main.bicep
@@ -19,8 +19,8 @@ param managedIdentityType string = 'SystemAssigned'
 @description('Required when managed identity type is set to UserAssigned')
 param userAssignedIdentities object = {}
 
-@description('Default is 1.24.3')
-param kubernetesVersion string = '1.24.3'
+@description('Default is 1.29')
+param kubernetesVersion string = '1.29'
 
 param defenderEnabled bool = false
 

--- a/cloud-native/aks-arm64/main.bicep
+++ b/cloud-native/aks-arm64/main.bicep
@@ -77,7 +77,7 @@ module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.1' = {
     tags: tags
     slaTier: 'Free'
     managedIdentityType: 'SystemAssigned'
-    kubernetesVersion: '1.24.3'
+    kubernetesVersion: '1.29'
     networkPlugin: networkPlugin
     networkPolicy: networkPolicy
     loadBalancerSku: 'Standard'

--- a/cloud-native/aks-arm64/main.json
+++ b/cloud-native/aks-arm64/main.json
@@ -443,7 +443,7 @@
             "value": "SystemAssigned"
           },
           "kubernetesVersion": {
-            "value": "1.24.3"
+            "value": "1.29"
           },
           "networkPlugin": {
             "value": "[variables('networkPlugin')]"
@@ -551,9 +551,9 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.24.3",
+              "defaultValue": "1.29",
               "metadata": {
-                "description": "Default is 1.24.3"
+                "description": "Default is 1.29"
               }
             },
             "defenderEnabled": {

--- a/cloud-native/aks-azure-linux/aks.bicep
+++ b/cloud-native/aks-azure-linux/aks.bicep
@@ -6,7 +6,7 @@ param gpu1VmSize string = 'Standard_NC4as_T4_v3'
 param gpu2VmSize string = 'Standard_NC6s_v3'
 //param gpu3VmSize string = 'Standard_NC24ads_A100_v4'
 
-param kubernetesVersion string = '1.27.3'
+param kubernetesVersion string = '1.29'
 
 var rand = substring(uniqueString(resourceGroup().id), 0, 6)
 

--- a/cloud-native/aks-bicep-k8s/aks.bicep
+++ b/cloud-native/aks-bicep-k8s/aks.bicep
@@ -2,7 +2,7 @@ param location string = resourceGroup().location
 param clusterName string = 'aks1'
 param nodeCount int = 1
 param vmSize string = 'standard_d2s_v5'
-param kubernetesVersion string = '1.27.1'
+param kubernetesVersion string = '1.29'
 
 var rand = substring(uniqueString(resourceGroup().id), 0, 6)
 

--- a/cloud-native/aks-bicep-keda/01-aks/aks.bicep
+++ b/cloud-native/aks-bicep-keda/01-aks/aks.bicep
@@ -2,7 +2,7 @@ param location string = resourceGroup().location
 param clusterName string = ''
 param nodeCount int = 1
 param vmSize string = 'standard_d2s_v3'
-param kubernetesVersion string = '1.23.5'
+param kubernetesVersion string = '1.29'
 
 var rand = substring(uniqueString(resourceGroup().id), 0, 6)
 var clusterName_var = clusterName != '' ? clusterName : 'aks1'

--- a/cloud-native/aks-bicep-keda/01-aks/main.json
+++ b/cloud-native/aks-bicep-keda/01-aks/main.json
@@ -77,7 +77,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.23.5"
+              "defaultValue": "1.29"
             }
           },
           "variables": {

--- a/cloud-native/aks-bicep/01-aks/aks.bicep
+++ b/cloud-native/aks-bicep/01-aks/aks.bicep
@@ -2,7 +2,7 @@ param location string = resourceGroup().location
 param clusterName string = ''
 param nodeCount int = 1
 param vmSize string = 'standard_d2s_v3'
-param kubernetesVersion string = '1.23.5'
+param kubernetesVersion string = '1.29'
 
 var rand = substring(uniqueString(resourceGroup().id), 0, 6)
 var clusterName_var = clusterName != '' ? clusterName : 'aks1'

--- a/cloud-native/aks-bicep/01-aks/main.json
+++ b/cloud-native/aks-bicep/01-aks/main.json
@@ -77,7 +77,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.23.5"
+              "defaultValue": "1.29"
             }
           },
           "variables": {

--- a/cloud-native/aks-kubeflow/magefile.go
+++ b/cloud-native/aks-kubeflow/magefile.go
@@ -61,7 +61,7 @@ func Aks() error {
 	}
 	kubernetesVersion := os.Getenv("AKS_KUBERNETES_VERSION")
 	if kubernetesVersion == "" {
-		kubernetesVersion = "1.24.9"
+		kubernetesVersion = "1.29"
 	}
 	cmd := []string{
 		"az",

--- a/cloud-native/aks-open-service-mesh/main.bicep
+++ b/cloud-native/aks-open-service-mesh/main.bicep
@@ -4,7 +4,7 @@ param name string
 param location string
 param tags object = {}
 
-param kubernetesVersion string = '1.24.3'
+param kubernetesVersion string = '1.29'
 param systemNodeCount int = 3
 param systemNodeSize string = 'Standard_D4s_v5'
 

--- a/cloud-native/aks-open-service-mesh/main.json
+++ b/cloud-native/aks-open-service-mesh/main.json
@@ -21,7 +21,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.24.3"
+      "defaultValue": "1.29"
     },
     "systemNodeCount": {
       "type": "int",
@@ -378,9 +378,9 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.24.3",
+              "defaultValue": "1.29",
               "metadata": {
-                "description": "Default is 1.24.3"
+                "description": "Default is 1.29"
               }
             },
             "defenderEnabled": {

--- a/cloud-native/aks-webapp-routing/main.bicep
+++ b/cloud-native/aks-webapp-routing/main.bicep
@@ -3,7 +3,7 @@ targetScope = 'subscription'
 param name string
 param location string
 param tags object = {}
-param kubernetesVersion string = '1.24.3'
+param kubernetesVersion string = '1.29'
 param systemNodeCount int = 3
 param systemNodeSize string = 'Standard_D4s_v5'
 param userObjectId string


### PR DESCRIPTION
Most of these templates use legacy Kubernetes versions.

Upgrading to the latest stable, 1.29