### PR TITLE
Use relative paths to bicep modules instead of using bicep registry

### DIFF
--- a/bicep/modules/azure-kubernetes-service/main.bicep
+++ b/bicep/modules/azure-kubernetes-service/main.bicep
@@ -63,6 +63,9 @@ param dnsServiceIP string = '10.0.0.10'
 @description('A CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range.')
 param dockerBridgeCidr string = '172.17.0.1/16'
 
+@description('Resource ID of log analytics workspace for auditing')
+param logAnalyticsWorkspaceResourceId string = ''
+
 @allowed([
   'loadBalancer'
   'managedNATGateway'

--- a/cloud-native/aks-arm64/main.bicep
+++ b/cloud-native/aks-arm64/main.bicep
@@ -15,7 +15,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 }
 
 // Set up the container registry
-module acr 'br/oss-labs:bicep/modules/azure-container-registry:v0.1' = {
+module acr '../../bicep/modules/azure-container-registry/main.bicep' = {
   scope: rg
   name: 'acrDeploy'
   params: {
@@ -30,7 +30,7 @@ module acr 'br/oss-labs:bicep/modules/azure-container-registry:v0.1' = {
 }
 
 // Set up the network security group
-module nsg 'br/oss-labs:bicep/modules/azure-network-security-group:v0.1' = if (networkPlugin != 'kubenet') {
+module nsg '../../bicep/modules/azure-network-security-group/main.bicep' = if (networkPlugin != 'kubenet') {
   scope: rg
   name: 'nsgDeploy'
   params: {
@@ -41,7 +41,7 @@ module nsg 'br/oss-labs:bicep/modules/azure-network-security-group:v0.1' = if (n
 }
 
 // Setup the virtual network and subnet
-module vnet 'br/oss-labs:bicep/modules/azure-virtual-network:v0.1' = if (networkPlugin != 'kubenet') {
+module vnet '../../bicep/modules/azure-virtual-network/main.bicep' = if (networkPlugin != 'kubenet') {
   scope: rg
   name: 'vnetDeploy'
   params: {
@@ -57,7 +57,7 @@ module vnet 'br/oss-labs:bicep/modules/azure-virtual-network:v0.1' = if (network
 }
 
 // Setup the log analytics workspace
-module law 'br/oss-labs:bicep/modules/azure-log-analytics-workspace:v0.1' = {
+module law '../../bicep/modules/azure-log-analytics-workspace/main.bicep' = {
   scope: rg
   name: 'lawDeploy'
   params: {
@@ -68,7 +68,7 @@ module law 'br/oss-labs:bicep/modules/azure-log-analytics-workspace:v0.1' = {
 }
 
 // Setup the Kubernetes cluster
-module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.1' = {
+module aks '../../bicep/modules/azure-kubernetes-service/main.bicep' = {
   scope: rg
   name: 'aksDeploy'
   params: {
@@ -98,13 +98,13 @@ module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.1' = {
     systemNodeVmSize: 'Standard_D2s_v5'
     registryName: acr.outputs.name
     vnetSubnetID: networkPlugin != 'kubenet' ? vnet.outputs.subnetId : ''
-    logAnalyticsWorkspaceResourceID: law.outputs.id
+    logAnalyticsWorkspaceResourceId: law.outputs.id
     nodeTaints: [ 'CriticalAddonsOnly=true:NoSchedule' ] // If deploying a user node pool too, you can taint the system node pool to prevent application pods from being scheduled on it; otherwise, leave empty
   }
 }
 
 // Setup the user node pools and deploy into a subnet
-module aksPools 'br/oss-labs:bicep/modules/azure-kubernetes-service-nodepools:v0.1' = {
+module aksPools '../../bicep/modules/azure-kubernetes-service-nodepools/main.bicep' = {
   scope: rg
   name: 'armNodePoolsDeploy'
   params: {

--- a/cloud-native/aks-open-service-mesh/main.bicep
+++ b/cloud-native/aks-open-service-mesh/main.bicep
@@ -21,7 +21,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   tags: tags
 }
 
-module kv 'br/oss-labs:bicep/modules/azure-key-vault:v0.1' = {
+module kv '../../bicep/modules/azure-key-vault/main.bicep' = {
   scope: rg
   name: 'akvDeploy'
   params: {
@@ -35,7 +35,7 @@ module kv 'br/oss-labs:bicep/modules/azure-key-vault:v0.1' = {
 }
 
 // Setup the log analytics workspace
-module law 'br/oss-labs:bicep/modules/azure-log-analytics-workspace:v0.1' = {
+module law '../../bicep/modules/azure-log-analytics-workspace/main.bicep' = {
   scope: rg
   name: 'lawDeploy'
   params: {
@@ -46,7 +46,7 @@ module law 'br/oss-labs:bicep/modules/azure-log-analytics-workspace:v0.1' = {
 }
 
 // Setup the Kubernetes cluster
-module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.2' = {
+module aks '../../bicep/modules/azure-kubernetes-service/main.bicep' = {
   scope: rg
   name: 'aksDeploy'
   params: {
@@ -87,7 +87,7 @@ module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.2' = {
 }
 
 // Deploy the key vault secrets provider add-on
-module aksAddonKv 'br/oss-labs:bicep/modules/azure-kubernetes-service-addons:v0.1' = {
+module aksAddonKv '../../bicep/modules/azure-kubernetes-service-addons/main.bicep' = {
   scope: rg
   name: 'aksAddonKvDeploy'
   params: {
@@ -110,7 +110,7 @@ module aksAddonKv 'br/oss-labs:bicep/modules/azure-kubernetes-service-addons:v0.
 }
 
 // Deploy the web app routing add-on
-module aksAddonIng 'br/oss-labs:bicep/modules/azure-kubernetes-service-ingress:v0.1' = {
+module aksAddonIng '../../bicep/modules/azure-kubernetes-service-ingress/main.bicep' = {
   scope: rg
   name: 'aksAddonIngDeploy'
   params: {
@@ -123,7 +123,7 @@ module aksAddonIng 'br/oss-labs:bicep/modules/azure-kubernetes-service-ingress:v
 }
 
 // Deploy the open service mesh add-on
-module aksAddonOsm 'br/oss-labs:bicep/modules/azure-kubernetes-service-addons:v0.1' = {
+module aksAddonOsm '../../bicep/modules/azure-kubernetes-service-addons/main.bicep' = {
   scope: rg
   name: 'aksAddonOsmDeploy'
   params: {

--- a/cloud-native/aks-webapp-routing/main.bicep
+++ b/cloud-native/aks-webapp-routing/main.bicep
@@ -20,7 +20,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 }
 
 // Deploy the Kubernetes cluster
-module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.2' = {
+module aks '../../bicep/modules/azure-kubernetes-service/main.bicep' = {
   scope: rg
   name: 'aksDeploy'
   params: {
@@ -36,7 +36,7 @@ module aks 'br/oss-labs:bicep/modules/azure-kubernetes-service:v0.2' = {
 }
 
 // Deploy the key vault
-module kv 'br/oss-labs:bicep/modules/azure-key-vault:v0.1' = {
+module kv '../../bicep/modules/azure-key-vault/main.bicep' = {
   scope: rg
   name: 'kvDeploy'
   params: {
@@ -68,7 +68,7 @@ module kv 'br/oss-labs:bicep/modules/azure-key-vault:v0.1' = {
 }
 
 // Deploy the public DNS zone
-module dns 'br/oss-labs:bicep/modules/azure-dns:v0.1' = {
+module dns '../../bicep/modules/azure-dns/main.bicep' = {
   scope: rg
   name: 'dnsDeploy'
   params: {
@@ -85,7 +85,7 @@ module dns 'br/oss-labs:bicep/modules/azure-dns:v0.1' = {
 }
 
 // Deploy the key vault secrets provider add-on
-module aksAddonKv 'br/oss-labs:bicep/modules/azure-kubernetes-service-addons:v0.1' = {
+module aksAddonKv '../../bicep/modules/azure-kubernetes-service-addons/main.bicep' = {
   scope: rg
   name: 'aksAddonKvDeploy'
   params: {
@@ -108,7 +108,7 @@ module aksAddonKv 'br/oss-labs:bicep/modules/azure-kubernetes-service-addons:v0.
 }
 
 // Deploy the web app routing add-on
-module aksAddonIng 'br/oss-labs:bicep/modules/azure-kubernetes-service-ingress:v0.1' = {
+module aksAddonIng '../../bicep/modules/azure-kubernetes-service-ingress/main.bicep' = {
   scope: rg
   name: 'aksAddonIngDeploy'
   params: {
@@ -128,7 +128,7 @@ module aksAddonIng 'br/oss-labs:bicep/modules/azure-kubernetes-service-ingress:v
 //   scope: mcResourceGroup
 // }
 
-// module aksAddonIngDns 'br/oss-labs:bicep/modules/azure-kubernetes-service-ingress-dns:v0.1' = {
+// module aksAddonIngDns '../../bicep/modules/azure-kubernetes-service-ingress-dns/main.bicep' = {
 //   scope: rg
 //   name: 'aksAddonIngDnsDeploy'
 //   params: {


### PR DESCRIPTION
This simplifies the repository by using relative paths to the `bicep/` directory instead of using bicep registry modules