### PR TITLE
Add cloud-native/aks-arm/

### DIFF
--- a/cloud-native/aks-arm/NOTES.md
+++ b/cloud-native/aks-arm/NOTES.md
@@ -1,0 +1,7 @@
+# NOTES
+
+https://azure.github.io/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/
+
+https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/container-service/managed-cluster#example-3-using-only-defaults
+
+https://techcommunity.microsoft.com/blog/linuxandopensourceblog/azure-linux-3-0-now-in-preview-on-azure-kubernetes-service-v1-31/4287229

--- a/cloud-native/aks-arm/README.md
+++ b/cloud-native/aks-arm/README.md
@@ -31,7 +31,7 @@ Create resource group:
 
 ```bash
 az group create \
-    --name 241200-aks \
+    --name 250100-aks \
     --location eastus
 ```
 
@@ -39,7 +39,7 @@ Deploy Azure Kubernetes Service (AKS) cluster:
 
 ```bash
 az deployment group create \
-    --resource-group 241200-aks \
+    --resource-group 250100-aks \
     --template-file cloud-native/aks-arm/aks.bicep
 ```
 
@@ -49,7 +49,7 @@ Deploy the empty Bicep template:
 
 ```bash
 az deployment group create \
-    --resource-group 241200-aks \
+    --resource-group 250100-aks \
     --mode Complete \
     --template-file cloud-native/aks-arm/empty.bicep
 ```

--- a/cloud-native/aks-arm/README.md
+++ b/cloud-native/aks-arm/README.md
@@ -1,0 +1,55 @@
+# Azure Kubernetes Service (AKS)
+
+## Prerequisites
+
+- Azure CLI
+- Bicep
+- Azure Subscription
+
+## Deploy
+
+Azure Linux V3 Preview feature registration:
+
+```bash
+az feature register \
+    --namespace Microsoft.ContainerService \
+    --name AzureLinuxV3Preview
+```
+
+```bash
+az feature show \
+    --namespace Microsoft.ContainerService \
+    --name AzureLinuxV3Preview
+```
+
+```bash
+az provider register \
+    -n Microsoft.ContainerService
+```
+
+Create resource group:
+
+```bash
+az group create \
+    --name 241200-aks \
+    --location eastus
+```
+
+Deploy Azure Kubernetes Service (AKS) cluster:
+
+```bash
+az deployment group create \
+    --resource-group 241200-aks \
+    --template-file cloud-native/aks-arm/aks.bicep
+```
+
+## Cleanup
+
+Deploy the empty Bicep template:
+
+```bash
+az deployment group create \
+    --resource-group 241200-aks \
+    --mode Complete \
+    --template-file cloud-native/aks-arm/empty.bicep
+```

--- a/cloud-native/aks-arm/aks.bicep
+++ b/cloud-native/aks-arm/aks.bicep
@@ -1,0 +1,42 @@
+param location string = resourceGroup().location
+
+var managedIdentityName = '${resourceGroup().name}-identity'
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: managedIdentityName
+  location: location
+}
+
+module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.5.0' = {
+  name: 'managedClusterDeployment'
+  params: {
+    // Required parameters
+    name: 'aks-1'
+    kubernetesVersion: '1.31.2'
+    primaryAgentPoolProfiles: [
+      {
+        count: 1
+        mode: 'System'
+        name: 'systempool'
+        osSku: 'AzureLinux'
+        vmSize: 'Standard_D2pds_v6'
+        orchestratorVersion: '1.31.2'
+      }
+      {
+        count: 1
+        mode: 'User'
+        name: 'pool1'
+        osSku: 'AzureLinux'
+        vmSize: 'Standard_D2pds_v6'
+        orchestratorVersion: '1.31.2'
+      }
+    ]
+    // Non-required parameters
+    location: location
+    managedIdentities: {
+      userAssignedResourcesIds: [
+        managedIdentity.id
+      ]
+    }
+  }
+}

--- a/cloud-native/aks-arm/aks.bicep
+++ b/cloud-native/aks-arm/aks.bicep
@@ -7,7 +7,7 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
   location: location
 }
 
-module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.5.0' = {
+module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.6.2' = {
   name: 'managedClusterDeployment'
   params: {
     // Required parameters
@@ -18,7 +18,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.5.0
         count: 1
         mode: 'System'
         name: 'systempool'
-        osSku: 'AzureLinux'
+        osSKU: 'AzureLinux'
         vmSize: 'Standard_D2pds_v6'
         orchestratorVersion: '1.31.2'
       }
@@ -26,15 +26,20 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.5.0
         count: 1
         mode: 'User'
         name: 'pool1'
-        osSku: 'AzureLinux'
+        osSKU: 'AzureLinux'
         vmSize: 'Standard_D2pds_v6'
         orchestratorVersion: '1.31.2'
       }
     ]
     // Non-required parameters
     location: location
+    aadProfile: {
+      aadProfileEnableAzureRBAC: true
+      aadProfileManaged: true
+    }
+    disableLocalAccounts: true
     managedIdentities: {
-      userAssignedResourcesIds: [
+      userAssignedResourceIds: [
         managedIdentity.id
       ]
     }


### PR DESCRIPTION
Adds support for Azure Kubernetes Service (AKS) with Azure Verified Modules (AVM) running Azure Linux with Cobalt 100-based nodes (https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/cobalt-overview ).